### PR TITLE
Android support

### DIFF
--- a/build_android/chromium-gost-build-release.sh
+++ b/build_android/chromium-gost-build-release.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd $(dirname $0)
+. ./chromium-gost-env.sh
+
+cd $CHROMIUM_PATH
+gn gen out/RELEASE --args="target_os=\"android\" target_cpu=\"arm64\" is_debug=false symbol_level=0 is_official_build=true treat_warnings_as_errors=false $CHROMIUM_FLAGS $CHROMIUM_PRIVATE_ARGS"
+ninja -C out/RELEASE chrome_public_apk

--- a/build_android/chromium-gost-env.sh
+++ b/build_android/chromium-gost-env.sh
@@ -1,0 +1,10 @@
+export CHROMIUM_TAG=$(cat ../VERSION)
+export CHROMIUM_FLAGS="$(cat ../FLAGS)"
+export CHROMIUM_PATH=/build/chromium/src
+export BORINGSSL_PATH=$CHROMIUM_PATH/third_party/boringssl/src
+export DEPOT_TOOLS_PATH=/build/depot_tools/
+export CHROMIUM_GOST_REPO=$(pwd)/..
+export CHROMIUM_PRIVATE_ARGS= 
+if [ -f ./chromium-gost-env-private.sh ]; then . ./chromium-gost-env-private.sh; fi
+if [ -f ~/chromium-gost-env-private.sh ]; then . ~/chromium-gost-env-private.sh; fi
+export PATH=$DEPOT_TOOLS_PATH:$DEPOT_TOOLS_PATH/python-bin:$PATH

--- a/build_android/chromium-gost-prepare.sh
+++ b/build_android/chromium-gost-prepare.sh
@@ -21,6 +21,7 @@ git checkout -b $GOST_BRANCH tags/$CHROMIUM_TAG
 git branch -D temp
 gclient sync --with_branch_heads -D
 git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/chromium.patch || exit
+git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/android.patch || exit
 
 perl -pi -e "s/Chromium/Chromium-Gost/g" chrome/app/chromium_strings.grd
 perl -pi -e "s/Chromium/Chromium-Gost/g" chrome/app/resources/chromium_strings*.xtb

--- a/build_android/chromium-gost-prepare.sh
+++ b/build_android/chromium-gost-prepare.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+cd $(dirname $0)
+git submodule update --init --recursive --depth 1
+. ./chromium-gost-env.sh
+
+export GOST_BRANCH=GOSTSSL-$CHROMIUM_TAG
+
+cd $CHROMIUM_PATH/.git || exit
+cd $BORINGSSL_PATH/.git || exit
+
+cd $BORINGSSL_PATH
+git reset HEAD~ --hard
+
+cd $CHROMIUM_PATH
+git reset HEAD~ --hard
+git fetch --tags
+git checkout -b temp tags/$CHROMIUM_TAG
+git show-ref --quiet refs/heads/$GOST_BRANCH && git branch -D $GOST_BRANCH
+git checkout -b $GOST_BRANCH tags/$CHROMIUM_TAG
+git branch -D temp
+gclient sync --with_branch_heads -D
+git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/chromium.patch || exit
+
+perl -pi -e "s/Chromium/Chromium-Gost/g" chrome/app/chromium_strings.grd
+perl -pi -e "s/Chromium/Chromium-Gost/g" chrome/app/resources/chromium_strings*.xtb
+cp -f $CHROMIUM_GOST_REPO/extra/exit_0.sh chrome/installer/linux/common/repo.cron
+cp -f $CHROMIUM_GOST_REPO/extra/exit_0.sh chrome/installer/linux/common/rpmrepo.cron
+
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/*.png chrome/app/theme/chromium/
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/*.png chrome/app/theme/chromium/linux/
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/product_logo_16.png chrome/app/theme/default_100_percent/chromium/product_logo_16.png
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/product_logo_32.png chrome/app/theme/default_100_percent/chromium/product_logo_32.png
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/product_logo_32.png chrome/app/theme/default_200_percent/chromium/product_logo_16.png
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/product_logo_64.png chrome/app/theme/default_200_percent/chromium/product_logo_32.png
+cp -f $CHROMIUM_GOST_REPO/extra/product_logo/product_logo_32.xpm chrome/app/theme/chromium/linux/product_logo_32.xpm
+
+cp -f $CHROMIUM_GOST_REPO/extra/favicon_ntp_16.png chrome/app/theme/default_100_percent/common/favicon_ntp.png
+cp -f $CHROMIUM_GOST_REPO/extra/favicon_ntp_32.png chrome/app/theme/default_200_percent/common/favicon_ntp.png
+
+cp -f $CHROMIUM_GOST_REPO/extra/colored_header.svg chrome/browser/resources/new_tab_page/icons/colored_header.svg
+cp -f $CHROMIUM_GOST_REPO/extra/chromium-gost.svg chrome/browser/resources/new_tab_page/icons/google_logo.svg
+
+cp -f $CHROMIUM_GOST_REPO/extra/external_extensions.json chrome/browser/resources/default_apps/external_extensions.json
+
+cp -f $CHROMIUM_GOST_REPO/src/gostssl.cpp third_party/boringssl/gostssl.cpp
+cp -f $CHROMIUM_GOST_REPO/src/msspi/src/msspi.cpp third_party/boringssl/msspi.cpp
+cp -f $CHROMIUM_GOST_REPO/src/msspi/src/msspi.h third_party/boringssl/msspi.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/src/capix.hpp third_party/boringssl/capix.hpp
+
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_SChannel.h third_party/boringssl/src/include/CSP_SChannel.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_Sspi.h third_party/boringssl/src/include/CSP_Sspi.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_WinBase.h third_party/boringssl/src/include/CSP_WinBase.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_WinCrypt.h third_party/boringssl/src/include/CSP_WinCrypt.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_WinDef.h third_party/boringssl/src/include/CSP_WinDef.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/CSP_WinError.h third_party/boringssl/src/include/CSP_WinError.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/WinCryptEx.h third_party/boringssl/src/include/WinCryptEx.h
+cp -f $CHROMIUM_GOST_REPO/src/msspi/third_party/cprocsp/include/common.h third_party/boringssl/src/include/common.h
+
+cd $BORINGSSL_PATH
+git checkout -b temp
+git show-ref --quiet refs/heads/$GOST_BRANCH && git branch -D $GOST_BRANCH
+git checkout -b $GOST_BRANCH
+git branch -D temp
+git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/boringssl.patch || exit

--- a/patch/android.patch
+++ b/patch/android.patch
@@ -1,14 +1,3 @@
-From 3c3db58d8846cdac8fad400a4d6b403bc884a074 Mon Sep 17 00:00:00 2001
-From: crypto-das <55387659+crypto-das@users.noreply.github.com>
-Date: Fri, 2 Feb 2024 13:05:29 +0000
-Subject: [PATCH] Android CSP integration
-
----
- chrome/android/BUILD.gn                       | 12 +++++++++
- chrome/android/chrome_public_apk_tmpl.gni     |  6 +++++
- .../chrome/browser/ChromeTabbedActivity.java  | 14 ++++++++++
- 3 files changed, 32 insertions(+)
-
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 index 271d8ffbb5b7b..18073719f9e95 100644
 --- a/chrome/android/BUILD.gn
@@ -35,14 +24,17 @@ index 271d8ffbb5b7b..18073719f9e95 100644
        ":chrome_app_java_resources",
        ":chrome_public_apk_template_resources",
 diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
-index 54c50b54bb7ca..2e08dd0a95453 100644
+index 54c50b54bb7ca..0f00e512bc425 100644
 --- a/chrome/android/chrome_public_apk_tmpl.gni
 +++ b/chrome/android/chrome_public_apk_tmpl.gni
-@@ -729,6 +729,12 @@ template("chrome_common_apk_or_module_tmpl") {
+@@ -729,6 +729,15 @@ template("chrome_common_apk_or_module_tmpl") {
        }
      }
  
-+    deps += [ "//chrome/android:cprocsp_shared_java" ]
++    deps += [
++      "//chrome/android:cprocsp_base_java",
++      "//chrome/android:cprocsp_gui_java"
++    ]
 +    loadable_modules += [
 +      "//third_party/cprocsp/jniLibs/arm64-v8a/libcspjni.so",
 +      "//third_party/cprocsp/jniLibs/arm64-v8a/libsupport.so"
@@ -88,3 +80,32 @@ index 74e852c79190b..2f5afed5e07f2 100644
      }
  
      @Override
+diff --git a/chrome/browser/search_engines/ui_thread_search_terms_data.h b/chrome/browser/search_engines/ui_thread_search_terms_data.h
+index 89658e9aa7b7e..8ad2461605751 100644
+--- a/chrome/browser/search_engines/ui_thread_search_terms_data.h
++++ b/chrome/browser/search_engines/ui_thread_search_terms_data.h
+@@ -28,7 +28,7 @@ class UIThreadSearchTermsData : public SearchTermsData {
+   std::string GoogleImageSearchSource() const override;
+ 
+ #if BUILDFLAG(IS_ANDROID)
+-  std::string GetYandexReferralID() const override;
++//  std::string GetYandexReferralID() const override;
+   std::string GetMailRUReferralID() const override;
+ #endif
+ 
+diff --git a/chrome/browser/search_engines/ui_thread_search_terms_data_android.cc b/chrome/browser/search_engines/ui_thread_search_terms_data_android.cc
+index 1278f9e64ed1f..79b5c56dfb04a 100644
+--- a/chrome/browser/search_engines/ui_thread_search_terms_data_android.cc
++++ b/chrome/browser/search_engines/ui_thread_search_terms_data_android.cc
+@@ -30,9 +30,11 @@ std::string UIThreadSearchTermsData::GetSearchClient() const {
+   return SearchTermsDataAndroid::search_client_.Get();
+ }
+ 
++#if 0
+ std::string UIThreadSearchTermsData::GetYandexReferralID() const {
+   return LocaleManager::GetYandexReferralID();
+ }
++#endif
+ 
+ std::string UIThreadSearchTermsData::GetMailRUReferralID() const {
+   return LocaleManager::GetMailRUReferralID();

--- a/patch/android.patch
+++ b/patch/android.patch
@@ -1,0 +1,94 @@
+From f267edd4736fd5bfd7b6d6e571201cdc8687d23f Mon Sep 17 00:00:00 2001
+From: crypto-das <55387659+crypto-das@users.noreply.github.com>
+Date: Fri, 2 Feb 2024 12:24:34 +0000
+Subject: [PATCH] Android CSP integration
+
+---
+ chrome/android/BUILD.gn                            | 12 ++++++++++++
+ chrome/android/chrome_public_apk_tmpl.gni          |  6 ++++++
+ .../chrome/browser/ChromeTabbedActivity.java       | 14 ++++++++++++++
+ 3 files changed, 32 insertions(+)
+
+diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
+index 30415d6d82652..9060a61c6627c 100644
+--- a/chrome/android/BUILD.gn
++++ b/chrome/android/BUILD.gn
+@@ -282,8 +282,20 @@ if (current_toolchain == default_toolchain) {
+     srcjar_deps = [ ":chrome_android_java_google_api_keys_srcjar" ]
+   }
+ 
++  android_aar_prebuilt("cprocsp_base_java") {
++    aar_path = "//third_party/cprocsp/libs/csp-base.aar"
++    info_path = "//third_party/cprocsp/libs/csp-base.info"
++  }
++
++  android_aar_prebuilt("cprocsp_gui_java") {
++    aar_path = "//third_party/cprocsp/libs/csp-gui.aar"
++    info_path = "//third_party/cprocsp/libs/csp-gui.info"
++  }
++
+   android_library("chrome_java") {
+     deps = [
++      ":cprocsp_base_java",
++      ":cprocsp_gui_java",
+       ":base_module_java",
+       ":chrome_app_java_resources",
+       ":chrome_public_apk_template_resources",
+diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
+index 2ed75910b0d62..290473a8ace4e 100644
+--- a/chrome/android/chrome_public_apk_tmpl.gni
++++ b/chrome/android/chrome_public_apk_tmpl.gni
+@@ -733,6 +733,12 @@ template("chrome_common_apk_or_module_tmpl") {
+       }
+     }
+ 
++    deps += [ "//chrome/android:cprocsp_shared_java" ]
++    loadable_modules += [
++      "//third_party/cprocsp/jniLibs/arm64-v8a/libcspjni.so",
++      "//third_party/cprocsp/jniLibs/arm64-v8a/libsupport.so"
++    ]
++
+     forward_variables_from(invoker,
+                            "*",
+                            TESTONLY_AND_VISIBILITY + [
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+index 43782c4bdc1e3..bd03ca3bb1c87 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -263,12 +263,23 @@ import java.util.Map;
+ import java.util.Set;
+ import java.util.concurrent.atomic.AtomicBoolean;
+ 
++import ru.CryptoPro.JCSP.NCSPConfig;
++
+ /**
+  * This is the main activity for ChromeMobile when not running in document mode. All the tabs are
+  * accessible via a chrome specific tab switching UI.
+  */
+ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent>
+         implements MismatchedIndicesHandler {
++    private static final String APP_LOGGER_TAG = "CSP";
++
++    private boolean initCSPProviders() {
++        int initCode   = NCSPConfig.init(this);
++        boolean initOk = initCode == NCSPConfig.CSP_INIT_OK;
++
++        return initOk;
++    }
++
+     private static final String TAG = "ChromeTabbedActivity";
+ 
+     protected static final String WINDOW_INDEX = "window_index";
+@@ -562,6 +573,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+                     }
+                     minimizeAppAndCloseTabOnBackPress(getActivityTab());
+                 });
++	if (!initCSPProviders()) {
++            Log.i(APP_LOGGER_TAG, "Couldn't initialize CSP.");
++        }
+     }
+ 
+     @Override
+-- 
+2.34.1
+

--- a/patch/android.patch
+++ b/patch/android.patch
@@ -1,19 +1,19 @@
-From f267edd4736fd5bfd7b6d6e571201cdc8687d23f Mon Sep 17 00:00:00 2001
+From 3c3db58d8846cdac8fad400a4d6b403bc884a074 Mon Sep 17 00:00:00 2001
 From: crypto-das <55387659+crypto-das@users.noreply.github.com>
-Date: Fri, 2 Feb 2024 12:24:34 +0000
+Date: Fri, 2 Feb 2024 13:05:29 +0000
 Subject: [PATCH] Android CSP integration
 
 ---
- chrome/android/BUILD.gn                            | 12 ++++++++++++
- chrome/android/chrome_public_apk_tmpl.gni          |  6 ++++++
- .../chrome/browser/ChromeTabbedActivity.java       | 14 ++++++++++++++
+ chrome/android/BUILD.gn                       | 12 +++++++++
+ chrome/android/chrome_public_apk_tmpl.gni     |  6 +++++
+ .../chrome/browser/ChromeTabbedActivity.java  | 14 ++++++++++
  3 files changed, 32 insertions(+)
 
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
-index 30415d6d82652..9060a61c6627c 100644
+index 271d8ffbb5b7b..18073719f9e95 100644
 --- a/chrome/android/BUILD.gn
 +++ b/chrome/android/BUILD.gn
-@@ -282,8 +282,20 @@ if (current_toolchain == default_toolchain) {
+@@ -284,8 +284,20 @@ if (current_toolchain == default_toolchain) {
      srcjar_deps = [ ":chrome_android_java_google_api_keys_srcjar" ]
    }
  
@@ -35,10 +35,10 @@ index 30415d6d82652..9060a61c6627c 100644
        ":chrome_app_java_resources",
        ":chrome_public_apk_template_resources",
 diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
-index 2ed75910b0d62..290473a8ace4e 100644
+index 54c50b54bb7ca..2e08dd0a95453 100644
 --- a/chrome/android/chrome_public_apk_tmpl.gni
 +++ b/chrome/android/chrome_public_apk_tmpl.gni
-@@ -733,6 +733,12 @@ template("chrome_common_apk_or_module_tmpl") {
+@@ -729,6 +729,12 @@ template("chrome_common_apk_or_module_tmpl") {
        }
      }
  
@@ -52,21 +52,20 @@ index 2ed75910b0d62..290473a8ace4e 100644
                             "*",
                             TESTONLY_AND_VISIBILITY + [
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-index 43782c4bdc1e3..bd03ca3bb1c87 100644
+index 74e852c79190b..2f5afed5e07f2 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-@@ -263,12 +263,23 @@ import java.util.Map;
+@@ -252,11 +252,22 @@ import java.util.Map;
  import java.util.Set;
  import java.util.concurrent.atomic.AtomicBoolean;
  
 +import ru.CryptoPro.JCSP.NCSPConfig;
 +
  /**
-  * This is the main activity for ChromeMobile when not running in document mode. All the tabs are
-  * accessible via a chrome specific tab switching UI.
+  * This is the main activity for ChromeMobile when not running in document mode.  All the tabs
+  * are accessible via a chrome specific tab switching UI.
   */
- public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent>
-         implements MismatchedIndicesHandler {
+ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent> {
 +    private static final String APP_LOGGER_TAG = "CSP";
 +
 +    private boolean initCSPProviders() {
@@ -79,7 +78,7 @@ index 43782c4bdc1e3..bd03ca3bb1c87 100644
      private static final String TAG = "ChromeTabbedActivity";
  
      protected static final String WINDOW_INDEX = "window_index";
-@@ -562,6 +573,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+@@ -525,6 +536,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
                      }
                      minimizeAppAndCloseTabOnBackPress(getActivityTab());
                  });
@@ -89,6 +88,3 @@ index 43782c4bdc1e3..bd03ca3bb1c87 100644
      }
  
      @Override
--- 
-2.34.1
-


### PR DESCRIPTION
Базовая поддержка сборки под Android. CSP интегрируется в apk файл, так что для сборки нужно скачать и подготовить дистрибутив CSP. Конкретные шаги пока здесь не описываю.