### PR TITLE
Fix KDE 6 without breaking UX

### DIFF
--- a/patch/chromium.patch
+++ b/patch/chromium.patch
@@ -1,9 +1,10 @@
-From f7b95f89090b4b1770d505a2880eb59b83965881 Mon Sep 17 00:00:00 2001
+From f9f8e283f6813f8cec27091887c7ecd2de4b349a Mon Sep 17 00:00:00 2001
 From: Dmitrii Pichulin <deem@deem.ru>
 Date: Wed, 13 May 2026 13:13:11 +0300
 Subject: [PATCH] chromium GOSTSSL
 
 ---
+ base/process/launch_posix.cc                  |  38 +++-
  chrome/BUILD.gn                               |   8 +-
  chrome/app/app-entitlements.plist             |   8 +
  chrome/app/generated_resources.grd            |   2 -
@@ -66,14 +67,74 @@ Subject: [PATCH] chromium GOSTSSL
  .../renderer/core/frame/reporting_context.h   |   5 +
  third_party/boringssl/BUILD.gn                |   1 +
  ui/linux/display_server_utils.cc              |   4 +-
- ui/qt/qt_ui.cc                                |  11 +
  .../cr_components/searchbox/searchbox.ts      |   8 +-
- 64 files changed, 978 insertions(+), 57 deletions(-)
+ 64 files changed, 1004 insertions(+), 58 deletions(-)
  create mode 100644 net/ssl/gostssl_util.cc
  create mode 100644 net/ssl/gostssl_util.h
 
+diff --git a/base/process/launch_posix.cc b/base/process/launch_posix.cc
+index 4f9ffed9d90a2..8761a375a6573 100644
+--- a/base/process/launch_posix.cc
++++ b/base/process/launch_posix.cc
+@@ -582,7 +582,36 @@ static bool GetAppOutputInternal(const std::vector<std::string>& argv,
+     return false;
+   }
+ 
+-  pid_t pid = fork();
++  // Use the raw clone syscall instead of fork() to bypass pthread_atfork
++  // handlers. In Chromium processes that load the KDE Plasma platform theme
++  // (KDEPlasmaPlatformTheme6.so), system libraries are loaded
++  // (KF6Notifications → libcanberra → libpulse, KIO workers, etc.). These
++  // libraries may create threads that hold PartitionAlloc locks when the
++  // browser thread calls fork(). glibc's fork() invokes pthread_atfork
++  // prepare handlers (registered by PartitionAlloc and GLib) which try to
++  // acquire those same locks → deadlock.
++  //
++  // https://github.com/deemru/Chromium-Gost/issues/135
++  //
++  // clone() with SIGCHLD creates a child process at the kernel level without
++  // invoking userspace pthread_atfork handlers. It is equivalent to what
++  // glibc's fork() does internally (both use SYS_clone), except fork() adds
++  // the atfork callbacks. This is safe because the child only performs
++  // async-signal-safe operations: open/dup2/close/execve/_exit.
++  //
++  // Passing 0 as child_stack means the child inherits the parent's stack
++  // pointer (same behavior as fork()). This is fine because execve()
++  // replaces the entire address space, and _exit() doesn't unwind.
++  //
++  // See crbug.com/36678 for child safety rules, crbug.com/902514 for why
++  // we need InvalidateTidCache() (normally done by a pthread_atfork child
++  // handler that we intentionally bypass).
++  //
++  // NOTE: We use the raw sycall (SYS_clone) rather than the libc clone()
++  // wrapper (from <sched.h>) because the wrapper requires a separate child
++  // stack when fn argument is non-null, and may have different behavior
++  // when called with null fn/stack across glibc versions.
++  pid_t pid = static_cast<pid_t>(syscall(SYS_clone, SIGCHLD, 0, 0, 0, 0));
+   switch (pid) {
+     case -1: {
+       // error
+@@ -595,11 +624,18 @@ static bool GetAppOutputInternal(const std::vector<std::string>& argv,
+       //
+       // DANGER: no calls to malloc or locks are allowed from now on:
+       // http://crbug.com/36678
++      //
++      // DANGER: do not return from this scope; the child does not have
++      // a dedicated stack and must end via _exit() or execve().
+ 
+ #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
+       // See comments on the ResetFDOwnership() declaration in
+       // base/files/scoped_file.h regarding why this is called early here.
+       subtle::ResetFDOwnership();
++      // clone() bypasses pthread_atfork handlers, so the TID cache is
++      // stale (still has the parent thread's TID). Invalidate it before
++      // doing anything else. See crbug.com/902514.
++      base::internal::InvalidateTidCache();
+ #endif
+ 
+       // Obscure fork() rule: in the child, if you don't end up doing exec*(),
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index cc98a1463c5..8d2479d2dad 100644
+index cc98a1463c539..8d2479d2dad5b 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -1520,7 +1520,7 @@ group("extra_resources") {
@@ -106,7 +167,7 @@ index cc98a1463c5..8d2479d2dad 100644
      }
    }
 diff --git a/chrome/app/app-entitlements.plist b/chrome/app/app-entitlements.plist
-index 79bf119fba7..2350f4b1d19 100644
+index 79bf119fba775..2350f4b1d19e9 100644
 --- a/chrome/app/app-entitlements.plist
 +++ b/chrome/app/app-entitlements.plist
 @@ -16,5 +16,13 @@
@@ -124,7 +185,7 @@ index 79bf119fba7..2350f4b1d19 100644
  </dict>
  </plist>
 diff --git a/chrome/app/generated_resources.grd b/chrome/app/generated_resources.grd
-index 33c0b42d826..51f2d22fbec 100644
+index 33c0b42d826b5..51f2d22fbec37 100644
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
 @@ -7633,10 +7633,8 @@ Keep your key file in a safe place. You will need it to create new versions of y
@@ -139,7 +200,7 @@ index 33c0b42d826..51f2d22fbec 100644
        <message name="IDS_GOOGLE_SEARCH_BOX_EMPTY_HINT_MULTIMODAL" desc="The text displayed in the multimodal searchbox when it is empty. It is meant to invite the user to add a text query to the existing image query in order to issue a 'multimodal' (image + text) query.">
          Add to your search
 diff --git a/chrome/app/resources/generated_resources_ru.xtb b/chrome/app/resources/generated_resources_ru.xtb
-index 33be5bb5f9a..00661683ea8 100644
+index 542efe4b89221..ab54b0569e339 100644
 --- a/chrome/app/resources/generated_resources_ru.xtb
 +++ b/chrome/app/resources/generated_resources_ru.xtb
 @@ -6021,7 +6021,7 @@
@@ -152,7 +213,7 @@ index 33be5bb5f9a..00661683ea8 100644
  <translation id="5155299520372681119">Время загрузки истекло. Файл удален.</translation>
  <translation id="5155327081870541046">В адресной строке введите быструю команду для сайта, на котором нужно выполнить поиск, например @bookmarks. Затем нажмите нужное сочетание клавиш и добавьте поисковый запрос.</translation>
 diff --git a/chrome/app/theme/chromium/BRANDING b/chrome/app/theme/chromium/BRANDING
-index f8363d5b294..2f8021eabe8 100644
+index f8363d5b294fe..2f8021eabe810 100644
 --- a/chrome/app/theme/chromium/BRANDING
 +++ b/chrome/app/theme/chromium/BRANDING
 @@ -1,10 +1,10 @@
@@ -175,7 +236,7 @@ index f8363d5b294..2f8021eabe8 100644
  MAC_CREATOR_CODE=Cr24
  MAC_TEAM_ID=
 diff --git a/chrome/browser/extensions/api/messaging/launch_context_posix.cc b/chrome/browser/extensions/api/messaging/launch_context_posix.cc
-index ebc06e12030..5fdaa13be3d 100644
+index ebc06e12030a1..5fdaa13be3d5a 100644
 --- a/chrome/browser/extensions/api/messaging/launch_context_posix.cc
 +++ b/chrome/browser/extensions/api/messaging/launch_context_posix.cc
 @@ -47,6 +47,18 @@ base::FilePath LaunchContext::FindManifest(const std::string& host_name,
@@ -198,7 +259,7 @@ index ebc06e12030..5fdaa13be3d 100644
    if (result.empty()) {
      error_message = "Can't find native messaging host " + host_name;
 diff --git a/chrome/browser/history/top_sites_factory.cc b/chrome/browser/history/top_sites_factory.cc
-index 3398a0e4ccb..5a198f0d314 100644
+index 3398a0e4ccb97..5a198f0d314d1 100644
 --- a/chrome/browser/history/top_sites_factory.cc
 +++ b/chrome/browser/history/top_sites_factory.cc
 @@ -54,7 +54,7 @@ struct RawPrepopulatedPage {
@@ -220,7 +281,7 @@ index 3398a0e4ccb..5a198f0d314 100644
    PrefService* pref_service = profile->GetPrefs();
    bool hide_web_store_icon =
 diff --git a/chrome/browser/metrics/key_credential_manager_support_reporter_win.cc b/chrome/browser/metrics/key_credential_manager_support_reporter_win.cc
-index 436bc47cadc..3c922aaefad 100644
+index 436bc47cadcb1..3c922aaefade9 100644
 --- a/chrome/browser/metrics/key_credential_manager_support_reporter_win.cc
 +++ b/chrome/browser/metrics/key_credential_manager_support_reporter_win.cc
 @@ -43,7 +43,7 @@ enum KeyCredentialManagerAvailability {
@@ -233,7 +294,7 @@ index 436bc47cadc..3c922aaefad 100644
  void ReportIsSupportedOutcome(KeyCredentialManagerAvailability availability) {
    base::UmaHistogramEnumeration(
 diff --git a/chrome/browser/resources/new_tab_page/app.ts b/chrome/browser/resources/new_tab_page/app.ts
-index 815e8f42bec..e0bce63b552 100644
+index 815e8f42bec8c..e0bce63b55234 100644
 --- a/chrome/browser/resources/new_tab_page/app.ts
 +++ b/chrome/browser/resources/new_tab_page/app.ts
 @@ -380,15 +380,15 @@ export class AppElement extends AppElementBase {
@@ -266,7 +327,7 @@ index 815e8f42bec..e0bce63b552 100644
    protected accessor multiLineEnabled_: boolean =
        loadTimeData.getBoolean('multiLineEnabled');
 diff --git a/chrome/browser/resources/new_tab_page/logo.css b/chrome/browser/resources/new_tab_page/logo.css
-index 4aabfc88bd5..c1ddf3320fb 100644
+index 4aabfc88bd528..c1ddf3320fb5d 100644
 --- a/chrome/browser/resources/new_tab_page/logo.css
 +++ b/chrome/browser/resources/new_tab_page/logo.css
 @@ -44,10 +44,7 @@
@@ -282,7 +343,7 @@ index 4aabfc88bd5..c1ddf3320fb 100644
  
  :host(:not([single-colored])) #logo {
 diff --git a/chrome/browser/resources/new_tab_page/logo.ts b/chrome/browser/resources/new_tab_page/logo.ts
-index d63d0527d53..00410f40509 100644
+index d63d0527d5394..00410f405097d 100644
 --- a/chrome/browser/resources/new_tab_page/logo.ts
 +++ b/chrome/browser/resources/new_tab_page/logo.ts
 @@ -99,10 +99,12 @@ export class LogoElement extends CrLitElement {
@@ -299,7 +360,7 @@ index d63d0527d53..00410f40509 100644
  
    override connectedCallback() {
 diff --git a/chrome/browser/search/search.cc b/chrome/browser/search/search.cc
-index bc22d3f807b..c27a1583527 100644
+index bc22d3f807baf..c27a1583527c5 100644
 --- a/chrome/browser/search/search.cc
 +++ b/chrome/browser/search/search.cc
 @@ -174,6 +174,8 @@ struct NewTabURLDetails {
@@ -312,7 +373,7 @@ index bc22d3f807b..c27a1583527 100644
      const bool default_is_google = DefaultSearchProviderIsGoogle(profile);
      const GURL local_url(default_is_google
 diff --git a/chrome/browser/shell_integration_linux.cc b/chrome/browser/shell_integration_linux.cc
-index 94c5e9be9e9..47f83519528 100644
+index 94c5e9be9e9a4..47f835195281f 100644
 --- a/chrome/browser/shell_integration_linux.cc
 +++ b/chrome/browser/shell_integration_linux.cc
 @@ -461,7 +461,7 @@ std::string GetIconName() {
@@ -325,7 +386,7 @@ index 94c5e9be9e9..47f83519528 100644
  }
  
 diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
-index 597bd5bfdcb..cc7a67583b0 100644
+index 597bd5bfdcbbf..cc7a67583b07e 100644
 --- a/chrome/browser/ui/startup/startup_browser_creator.cc
 +++ b/chrome/browser/ui/startup/startup_browser_creator.cc
 @@ -144,6 +144,17 @@
@@ -533,7 +594,7 @@ index 597bd5bfdcb..cc7a67583b0 100644
  
  #if BUILDFLAG(IS_WIN)
 diff --git a/chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.cc b/chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.cc
-index 3c310d91b55..087ef45ec14 100644
+index 3c310d91b5591..087ef45ec145b 100644
 --- a/chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.cc
 +++ b/chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.cc
 @@ -139,6 +139,8 @@ bool AreNewChromeLabsExperimentsAvailable(Profile* profile) {
@@ -546,7 +607,7 @@ index 3c310d91b55..087ef45ec14 100644
    if (chrome::GetChannel() == version_info::Channel::STABLE) {
      return false;
 diff --git a/chrome/browser/ui/views/certificate_selector.cc b/chrome/browser/ui/views/certificate_selector.cc
-index f33e742199d..f5b2ccee006 100644
+index f33e742199d99..f5b2ccee00649 100644
 --- a/chrome/browser/ui/views/certificate_selector.cc
 +++ b/chrome/browser/ui/views/certificate_selector.cc
 @@ -71,8 +71,8 @@ bool UseGlicDevFlow(content::WebContents* contents) {
@@ -611,7 +672,7 @@ index f33e742199d..f5b2ccee006 100644
    for (auto& column : columns) {
      column.sortable = true;
 diff --git a/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc b/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc
-index 3f8871e197a..487c0be0091 100644
+index 3f8871e197aa2..487c0be00917c 100644
 --- a/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc
 +++ b/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc
 @@ -309,6 +309,7 @@ void BrowserAppMenuButton::UpdateTextAndHighlightColor() {
@@ -623,7 +684,7 @@ index 3f8871e197a..487c0be0091 100644
  
    SetTooltipText(l10n_util::GetStringUTF16(tooltip_message_id));
 diff --git a/chrome/browser/ui/webui/whats_new/whats_new_util.cc b/chrome/browser/ui/webui/whats_new/whats_new_util.cc
-index 8b12affd2b9..143b415c524 100644
+index 8b12affd2b97b..143b415c52455 100644
 --- a/chrome/browser/ui/webui/whats_new/whats_new_util.cc
 +++ b/chrome/browser/ui/webui/whats_new/whats_new_util.cc
 @@ -100,7 +100,7 @@ bool ShouldShowForState(PrefService* local_state,
@@ -636,7 +697,7 @@ index 8b12affd2b9..143b415c524 100644
  }
  
 diff --git a/chrome/common/channel_info_posix.cc b/chrome/common/channel_info_posix.cc
-index f6bcb3cc8e8..dc53b2f53f8 100644
+index f6bcb3cc8e8d6..dc53b2f53f8e8 100644
 --- a/chrome/common/channel_info_posix.cc
 +++ b/chrome/common/channel_info_posix.cc
 @@ -148,7 +148,7 @@ std::string GetDesktopName(base::Environment* env) {
@@ -649,7 +710,7 @@ index f6bcb3cc8e8..dc53b2f53f8 100644
  }
  #endif  // BUILDFLAG(IS_LINUX)
 diff --git a/chrome/common/net/x509_certificate_model.cc b/chrome/common/net/x509_certificate_model.cc
-index 4b76cfb0640..23892e17f5a 100644
+index 4b76cfb0640f5..23892e17f5a2f 100644
 --- a/chrome/common/net/x509_certificate_model.cc
 +++ b/chrome/common/net/x509_certificate_model.cc
 @@ -565,7 +565,7 @@ std::string ProcessRDN(const bssl::RelativeDistinguishedName& rdn) {
@@ -662,7 +723,7 @@ index 4b76cfb0640..23892e17f5a 100644
      rv += " = ";
      if (name_attribute.type == bssl::der::Input(bssl::kTypeCommonNameOid)) {
 diff --git a/chrome/installer/linux/common/apt.include b/chrome/installer/linux/common/apt.include
-index d7049c7cb8a..0a9526bd474 100644
+index d7049c7cb8a73..0a9526bd4745e 100644
 --- a/chrome/installer/linux/common/apt.include
 +++ b/chrome/installer/linux/common/apt.include
 @@ -19,6 +19,7 @@ find_apt_sources() {
@@ -712,7 +773,7 @@ index d7049c7cb8a..0a9526bd474 100644
 +  fi
  }
 diff --git a/chrome/installer/linux/common/chromium-browser.info b/chrome/installer/linux/common/chromium-browser.info
-index 395c019f7dd..91fa16c4ed3 100644
+index 395c019f7dd5f..91fa16c4ed39c 100644
 --- a/chrome/installer/linux/common/chromium-browser.info
 +++ b/chrome/installer/linux/common/chromium-browser.info
 @@ -6,25 +6,25 @@
@@ -747,7 +808,7 @@ index 395c019f7dd..91fa16c4ed3 100644
  # Package maintainer information.
  MAINTNAME="Chromium Linux Team"
 diff --git a/chrome/installer/linux/common/rpm.include b/chrome/installer/linux/common/rpm.include
-index 9965c822705..8b93287681e 100644
+index 9965c8227052c..8b93287681ece 100644
 --- a/chrome/installer/linux/common/rpm.include
 +++ b/chrome/installer/linux/common/rpm.include
 @@ -4,6 +4,7 @@
@@ -811,7 +872,7 @@ index 9965c822705..8b93287681e 100644
  
  update_repo_file() {
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index 0f331c3e0f2..87626fc3e11 100644
+index 0f331c3e0f2a3..87626fc3e119b 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
 @@ -39,7 +39,7 @@ v8_context_snapshot.bin: %(VersionDir)s\
@@ -824,7 +885,7 @@ index 0f331c3e0f2..87626fc3e11 100644
  
  #
 diff --git a/chrome/installer/setup/install_worker.cc b/chrome/installer/setup/install_worker.cc
-index feeca02961e..ca58dcdbf7c 100644
+index feeca02961ebd..ca58dcdbf7c6c 100644
 --- a/chrome/installer/setup/install_worker.cc
 +++ b/chrome/installer/setup/install_worker.cc
 @@ -289,6 +289,7 @@ void AddChromeWorkItems(const InstallParams& install_params,
@@ -857,7 +918,7 @@ index feeca02961e..ca58dcdbf7c 100644
    AddUpdateDowngradeVersionItem(installer_state.root_key(), current_version,
                                  new_version, install_list);
 diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
-index 557eadb1822..30c506d8b4e 100644
+index 557eadb18229e..30c506d8b4e50 100644
 --- a/components/embedder_support/user_agent_utils.cc
 +++ b/components/embedder_support/user_agent_utils.cc
 @@ -915,7 +915,7 @@ std::string BuildUserAgentFromOSAndProduct(const std::string& os_info,
@@ -870,7 +931,7 @@ index 557eadb1822..30c506d8b4e 100644
                        os_info.c_str(), product.c_str());
    return user_agent;
 diff --git a/components/search_engines/keyword_table.cc b/components/search_engines/keyword_table.cc
-index 47c1b2c5771..81280194129 100644
+index 47c1b2c577122..812801941291e 100644
 --- a/components/search_engines/keyword_table.cc
 +++ b/components/search_engines/keyword_table.cc
 @@ -584,7 +584,9 @@ std::optional<TemplateURLData> KeywordTable::GetKeywordDataFromStatement(
@@ -894,7 +955,7 @@ index 47c1b2c5771..81280194129 100644
    // TODO(b:322513019): support other regulatory programs.
    s->BindBool(starting_column + 21,
 diff --git a/components/search_engines/search_terms_data.cc b/components/search_engines/search_terms_data.cc
-index edc375b207c..0f586fe7986 100644
+index edc375b207c0d..0f586fe798687 100644
 --- a/components/search_engines/search_terms_data.cc
 +++ b/components/search_engines/search_terms_data.cc
 @@ -155,7 +155,7 @@ std::string SearchTermsData::GoogleImageSearchSource() const {
@@ -907,7 +968,7 @@ index edc375b207c..0f586fe7986 100644
  
  std::string SearchTermsData::GetMailRUReferralID() const {
 diff --git a/components/search_engines/template_url_data_util.cc b/components/search_engines/template_url_data_util.cc
-index 8c02d0e784b..0f528a1765b 100644
+index 8c02d0e784b39..0f528a1765b13 100644
 --- a/components/search_engines/template_url_data_util.cc
 +++ b/components/search_engines/template_url_data_util.cc
 @@ -77,10 +77,12 @@ std::unique_ptr<TemplateURLData> TemplateURLDataFromDictionary(
@@ -946,7 +1007,7 @@ index 8c02d0e784b..0f528a1765b 100644
      if (string_value) {
        contextual_search_url = *string_value;
 diff --git a/components/search_engines/template_url_prepopulate_data.cc b/components/search_engines/template_url_prepopulate_data.cc
-index 23c3c13f2f0..8c4b1746b4f 100644
+index 23c3c13f2f0ec..8c4b1746b4f66 100644
 --- a/components/search_engines/template_url_prepopulate_data.cc
 +++ b/components/search_engines/template_url_prepopulate_data.cc
 @@ -184,8 +184,14 @@ std::vector<std::unique_ptr<TemplateURLData>> GetPrepopulatedEngines(
@@ -976,7 +1037,7 @@ index 23c3c13f2f0..8c4b1746b4f 100644
  }
  
 diff --git a/content/browser/service_host/utility_process_host.cc b/content/browser/service_host/utility_process_host.cc
-index 1b6c5d15eaf..18977cf172e 100644
+index 1b6c5d15eaf06..18977cf172e03 100644
 --- a/content/browser/service_host/utility_process_host.cc
 +++ b/content/browser/service_host/utility_process_host.cc
 @@ -383,6 +383,12 @@ bool UtilityProcessHost::StartProcess() {
@@ -993,7 +1054,7 @@ index 1b6c5d15eaf..18977cf172e 100644
        network::switches::kForceEffectiveConnectionType,
        network::switches::kHostResolverRules,
 diff --git a/content/browser/storage_partition_impl.cc b/content/browser/storage_partition_impl.cc
-index ab16e6b1590..5a589cf4ab9 100644
+index ab16e6b15905b..5a589cf4ab9e0 100644
 --- a/content/browser/storage_partition_impl.cc
 +++ b/content/browser/storage_partition_impl.cc
 @@ -175,6 +175,10 @@
@@ -1020,7 +1081,7 @@ index ab16e6b1590..5a589cf4ab9 100644
      if (cert && private_key) {
        mojo::PendingRemote<network::mojom::SSLPrivateKey> ssl_private_key;
 diff --git a/net/BUILD.gn b/net/BUILD.gn
-index 19c01e132bf..9456cdd3e5f 100644
+index 19c01e132bf04..9456cdd3e5f2c 100644
 --- a/net/BUILD.gn
 +++ b/net/BUILD.gn
 @@ -1129,6 +1129,8 @@ component("net") {
@@ -1033,7 +1094,7 @@ index 19c01e132bf..9456cdd3e5f 100644
      "ssl/openssl_private_key.h",
      "ssl/openssl_ssl_util.cc",
 diff --git a/net/base/net_error_list.h b/net/base/net_error_list.h
-index 52f3b5b7db3..890c9250e1d 100644
+index 52f3b5b7db346..890c9250e1d45 100644
 --- a/net/base/net_error_list.h
 +++ b/net/base/net_error_list.h
 @@ -23,6 +23,11 @@
@@ -1049,7 +1110,7 @@ index 52f3b5b7db3..890c9250e1d 100644
  
  // An asynchronous IO operation is not yet complete.  This usually does not
 diff --git a/net/cert/cert_verify_proc.cc b/net/cert/cert_verify_proc.cc
-index d12efbc9a37..408824039b6 100644
+index d12efbc9a3705..408824039b667 100644
 --- a/net/cert/cert_verify_proc.cc
 +++ b/net/cert/cert_verify_proc.cc
 @@ -427,6 +427,12 @@ CertVerifyProc::CertVerifyProc(scoped_refptr<CRLSet> crl_set)
@@ -1090,7 +1151,7 @@ index d12efbc9a37..408824039b6 100644
    // in the chain. Also fills in the has_* booleans for the digest algorithms
    // present in the chain.
 diff --git a/net/cert/x509_cert_types.cc b/net/cert/x509_cert_types.cc
-index 3481e5b3eb0..1368d63c23a 100644
+index 3481e5b3eb079..1368d63c23ad0 100644
 --- a/net/cert/x509_cert_types.cc
 +++ b/net/cert/x509_cert_types.cc
 @@ -43,6 +43,20 @@ bool CertPrincipal::ParseDistinguishedName(
@@ -1136,7 +1197,7 @@ index 3481e5b3eb0..1368d63c23a 100644
      return organization_names[0];
    if (!organization_unit_names.empty())
 diff --git a/net/cert/x509_cert_types.h b/net/cert/x509_cert_types.h
-index c6c544bec55..11c9d941f21 100644
+index c6c544bec555a..11c9d941f217e 100644
 --- a/net/cert/x509_cert_types.h
 +++ b/net/cert/x509_cert_types.h
 @@ -44,6 +44,8 @@ struct NET_EXPORT CertPrincipal {
@@ -1149,7 +1210,7 @@ index c6c544bec55..11c9d941f21 100644
    std::string state_or_province_name;
    std::string country_name;
 diff --git a/net/http/http_network_transaction.cc b/net/http/http_network_transaction.cc
-index 9a8e75c7a46..462f2f56958 100644
+index 9a8e75c7a4622..462f2f569582c 100644
 --- a/net/http/http_network_transaction.cc
 +++ b/net/http/http_network_transaction.cc
 @@ -2018,6 +2018,15 @@ int HttpNetworkTransaction::HandleSSLClientAuthError(int error) {
@@ -1169,7 +1230,7 @@ index 9a8e75c7a46..462f2f56958 100644
  }
  
 diff --git a/net/socket/socket.h b/net/socket/socket.h
-index 64e08182d66..c52bc4bfb34 100644
+index 64e08182d6647..c52bc4bfb349e 100644
 --- a/net/socket/socket.h
 +++ b/net/socket/socket.h
 @@ -21,6 +21,10 @@ class IOBuffer;
@@ -1184,7 +1245,7 @@ index 64e08182d66..c52bc4bfb34 100644
    virtual ~Socket();
  
 diff --git a/net/socket/ssl_client_socket.cc b/net/socket/ssl_client_socket.cc
-index 886bfe6e055..d3bd488b63b 100644
+index 886bfe6e05595..d3bd488b63bfd 100644
 --- a/net/socket/ssl_client_socket.cc
 +++ b/net/socket/ssl_client_socket.cc
 @@ -23,6 +23,10 @@
@@ -1211,7 +1272,7 @@ index 886bfe6e055..d3bd488b63b 100644
  
  SSLClientContext::~SSLClientContext() {
 diff --git a/net/socket/ssl_client_socket.h b/net/socket/ssl_client_socket.h
-index cb52207b20d..25530af3ebe 100644
+index cb52207b20deb..25530af3ebe4c 100644
 --- a/net/socket/ssl_client_socket.h
 +++ b/net/socket/ssl_client_socket.h
 @@ -257,6 +257,10 @@ class NET_EXPORT SSLClientContext : public SSLConfigService::Observer,
@@ -1226,7 +1287,7 @@ index cb52207b20d..25530af3ebe 100644
    void NotifySSLConfigChanged(SSLConfigChangeType change_type);
    void NotifySSLConfigForServersChanged(
 diff --git a/net/socket/ssl_client_socket_impl.cc b/net/socket/ssl_client_socket_impl.cc
-index 8ac44772109..9100034846a 100644
+index 8ac44772109a8..9100034846a17 100644
 --- a/net/socket/ssl_client_socket_impl.cc
 +++ b/net/socket/ssl_client_socket_impl.cc
 @@ -14,6 +14,7 @@
@@ -1492,7 +1553,7 @@ index 8ac44772109..9100034846a 100644
    if (client_cert_.get()) {
      if (!client_private_key_) {
 diff --git a/net/socket/ssl_client_socket_impl.h b/net/socket/ssl_client_socket_impl.h
-index ef87745a097..b624eb33434 100644
+index ef87745a097fe..b624eb33434e2 100644
 --- a/net/socket/ssl_client_socket_impl.h
 +++ b/net/socket/ssl_client_socket_impl.h
 @@ -54,6 +54,14 @@ class NET_EXPORT_PRIVATE SSLClientSocketImpl
@@ -1511,7 +1572,7 @@ index ef87745a097..b624eb33434 100644
    // The given hostname will be compared with the name(s) in the server's
    // certificate during the SSL handshake.  |ssl_config| specifies the SSL
 diff --git a/net/spdy/spdy_session.cc b/net/spdy/spdy_session.cc
-index 01c092ea928..b765a1e735b 100644
+index 01c092ea928e3..b765a1e735b89 100644
 --- a/net/spdy/spdy_session.cc
 +++ b/net/spdy/spdy_session.cc
 @@ -1556,6 +1556,11 @@ void SpdySession::RemovePooledAlias(const SpdySessionKey& alias_key) {
@@ -1527,7 +1588,7 @@ index 01c092ea928..b765a1e735b 100644
    CHECK(GetSSLInfo(&ssl_info));
  
 diff --git a/net/ssl/client_cert_store_mac.cc b/net/ssl/client_cert_store_mac.cc
-index c92d91d72dd..66cdbe8cca8 100644
+index c92d91d72dd8f..66cdbe8cca807 100644
 --- a/net/ssl/client_cert_store_mac.cc
 +++ b/net/ssl/client_cert_store_mac.cc
 @@ -298,6 +298,12 @@ void AddIdentity(ScopedCFTypeRef<SecIdentityRef> sec_identity,
@@ -1596,7 +1657,7 @@ index c92d91d72dd..66cdbe8cca8 100644
  }
  
 diff --git a/net/ssl/client_cert_store_nss.cc b/net/ssl/client_cert_store_nss.cc
-index 049a61fefb8..7a122e833a9 100644
+index 049a61fefb810..7a122e833a9d2 100644
 --- a/net/ssl/client_cert_store_nss.cc
 +++ b/net/ssl/client_cert_store_nss.cc
 @@ -133,6 +133,12 @@ void ClientCertStoreNSS::FilterCertsOnWorkerThread(
@@ -1667,7 +1728,7 @@ index 049a61fefb8..7a122e833a9 100644
  }
  
 diff --git a/net/ssl/client_cert_store_win.cc b/net/ssl/client_cert_store_win.cc
-index 29f6b979931..299ed18c7d3 100644
+index 29f6b979931fd..299ed18c7d307 100644
 --- a/net/ssl/client_cert_store_win.cc
 +++ b/net/ssl/client_cert_store_win.cc
 @@ -108,6 +108,12 @@ static BOOL WINAPI ClientCertFindCallback(PCCERT_CONTEXT cert_context,
@@ -1738,7 +1799,7 @@ index 29f6b979931..299ed18c7d3 100644
    return selected_identities;
 diff --git a/net/ssl/gostssl_util.cc b/net/ssl/gostssl_util.cc
 new file mode 100644
-index 00000000000..84a02f3dd35
+index 0000000000000..84a02f3dd3502
 --- /dev/null
 +++ b/net/ssl/gostssl_util.cc
 @@ -0,0 +1,46 @@
@@ -1790,7 +1851,7 @@ index 00000000000..84a02f3dd35
 +#endif  // NO_GOSTSSL
 diff --git a/net/ssl/gostssl_util.h b/net/ssl/gostssl_util.h
 new file mode 100644
-index 00000000000..902624321a5
+index 0000000000000..902624321a599
 --- /dev/null
 +++ b/net/ssl/gostssl_util.h
 @@ -0,0 +1,16 @@
@@ -1811,7 +1872,7 @@ index 00000000000..902624321a5
 +
 +#endif  // NET_SSL_GOSTSSL_UTIL_H_
 diff --git a/net/ssl/openssl_ssl_util.cc b/net/ssl/openssl_ssl_util.cc
-index 09b38ddb174..d2b58f6d253 100644
+index 09b38ddb17496..d2b58f6d25300 100644
 --- a/net/ssl/openssl_ssl_util.cc
 +++ b/net/ssl/openssl_ssl_util.cc
 @@ -72,6 +72,10 @@ int MapOpenSSLErrorSSL(uint32_t error_code) {
@@ -1826,7 +1887,7 @@ index 09b38ddb174..d2b58f6d253 100644
      case SSL_R_SSLV3_ALERT_UNSUPPORTED_CERTIFICATE:
      case SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED:
 diff --git a/net/ssl/ssl_cipher_suite_names.cc b/net/ssl/ssl_cipher_suite_names.cc
-index c97eaf3c238..b909eb7d5e8 100644
+index c97eaf3c238ca..b909eb7d5e8e2 100644
 --- a/net/ssl/ssl_cipher_suite_names.cc
 +++ b/net/ssl/ssl_cipher_suite_names.cc
 @@ -68,6 +68,63 @@ void SSLCipherSuiteToStrings(const char** key_exchange_str,
@@ -1913,7 +1974,7 @@ index c97eaf3c238..b909eb7d5e8 100644
  
    obsolete_ssl |= ObsoleteSSLStatusForSignature(signature_algorithm);
 diff --git a/net/ssl/ssl_config_service.cc b/net/ssl/ssl_config_service.cc
-index 156eff3ef3e..1de7770f21b 100644
+index 156eff3ef3e5f..1de7770f21bb4 100644
 --- a/net/ssl/ssl_config_service.cc
 +++ b/net/ssl/ssl_config_service.cc
 @@ -27,7 +27,7 @@ namespace {
@@ -1926,7 +1987,7 @@ index 156eff3ef3e..1de7770f21b 100644
      {.group_id = SSL_GROUP_SECP256R1, .send_key_share = false},
      {.group_id = SSL_GROUP_SECP384R1, .send_key_share = false},
 diff --git a/net/ssl/ssl_platform_key_util.cc b/net/ssl/ssl_platform_key_util.cc
-index 987a2254cf6..04da6ab681c 100644
+index 987a2254cf618..04da6ab681c95 100644
 --- a/net/ssl/ssl_platform_key_util.cc
 +++ b/net/ssl/ssl_platform_key_util.cc
 @@ -51,6 +51,28 @@ scoped_refptr<base::SingleThreadTaskRunner> GetSSLPlatformKeyTaskRunner() {
@@ -1959,7 +2020,7 @@ index 987a2254cf6..04da6ab681c 100644
      const X509Certificate* certificate) {
    crypto::OpenSSLErrStackTracer tracker(FROM_HERE);
 diff --git a/net/ssl/ssl_platform_key_util.h b/net/ssl/ssl_platform_key_util.h
-index 2b2634c6888..3884282913f 100644
+index 2b2634c68884a..3884282913fb2 100644
 --- a/net/ssl/ssl_platform_key_util.h
 +++ b/net/ssl/ssl_platform_key_util.h
 @@ -15,6 +15,9 @@
@@ -1984,7 +2045,7 @@ index 2b2634c6888..3884282913f 100644
  NET_EXPORT_PRIVATE bssl::UniquePtr<EVP_PKEY> GetClientCertPublicKey(
      const X509Certificate* certificate);
 diff --git a/sandbox/policy/features.cc b/sandbox/policy/features.cc
-index 897abc35a68..5589d6a6d11 100644
+index 897abc35a68e4..5589d6a6d1119 100644
 --- a/sandbox/policy/features.cc
 +++ b/sandbox/policy/features.cc
 @@ -25,13 +25,13 @@ BASE_FEATURE(kNetworkServiceSandbox, base::FEATURE_DISABLED_BY_DEFAULT);
@@ -2013,7 +2074,7 @@ index 897abc35a68..5589d6a6d11 100644
  // Enables Renderer AppContainer
  BASE_FEATURE(kRendererAppContainer, base::FEATURE_DISABLED_BY_DEFAULT);
 diff --git a/sandbox/policy/mac/common.sb b/sandbox/policy/mac/common.sb
-index 955c7aa9bf8..d5785cce57c 100644
+index 955c7aa9bf85d..d5785cce57c42 100644
 --- a/sandbox/policy/mac/common.sb
 +++ b/sandbox/policy/mac/common.sb
 @@ -195,6 +195,23 @@
@@ -2041,7 +2102,7 @@ index 955c7aa9bf8..d5785cce57c 100644
  ; This is read by CFPrefs calling getpwuid in a loop. libinfo then fails to
  ; contact any of the opendirectoryd mach services, and falls back to
 diff --git a/sandbox/win/src/process_mitigations.cc b/sandbox/win/src/process_mitigations.cc
-index abc9837b2b0..d5ee53233cb 100644
+index abc9837b2b044..d5ee53233cbd4 100644
 --- a/sandbox/win/src/process_mitigations.cc
 +++ b/sandbox/win/src/process_mitigations.cc
 @@ -227,6 +227,7 @@ bool ApplyProcessMitigationsToCurrentProcess(MitigationFlags starting_flags,
@@ -2077,7 +2138,7 @@ index abc9837b2b0..d5ee53233cb 100644
  
    // Enable image load policies.
 diff --git a/services/network/network_service.cc b/services/network/network_service.cc
-index 3989a72d732..cb3e277e9f6 100644
+index 3989a72d732e1..cb3e277e9f6db 100644
 --- a/services/network/network_service.cc
 +++ b/services/network/network_service.cc
 @@ -77,6 +77,7 @@
@@ -2100,7 +2161,7 @@ index 3989a72d732..cb3e277e9f6 100644
    // Measure Android kernels with missing AT_HWCAP2 auxv fields. See
    // https://crbug.com/boringssl/46.
 diff --git a/third_party/blink/renderer/core/frame/reporting_context.cc b/third_party/blink/renderer/core/frame/reporting_context.cc
-index 9b146e778a8..fbd6fe8e341 100644
+index 9b146e778a8e4..fbd6fe8e34140 100644
 --- a/third_party/blink/renderer/core/frame/reporting_context.cc
 +++ b/third_party/blink/renderer/core/frame/reporting_context.cc
 @@ -59,7 +59,9 @@ const char ReportingContext::kSupplementName[] = "ReportingContext";
@@ -2156,7 +2217,7 @@ index 9b146e778a8..fbd6fe8e341 100644
  
  }  // namespace blink
 diff --git a/third_party/blink/renderer/core/frame/reporting_context.h b/third_party/blink/renderer/core/frame/reporting_context.h
-index 48d64ece3de..1749703e33c 100644
+index 48d64ece3def4..1749703e33cd6 100644
 --- a/third_party/blink/renderer/core/frame/reporting_context.h
 +++ b/third_party/blink/renderer/core/frame/reporting_context.h
 @@ -5,6 +5,7 @@
@@ -2192,7 +2253,7 @@ index 48d64ece3de..1749703e33c 100644
    // There might be up to two ReportingObservers stored here: one that is called
    // from the CrossOriginEmbedderPolicyReporter and one that is called from the
 diff --git a/third_party/boringssl/BUILD.gn b/third_party/boringssl/BUILD.gn
-index 708bb206626..883414554c8 100644
+index 708bb2066269b..883414554c832 100644
 --- a/third_party/boringssl/BUILD.gn
 +++ b/third_party/boringssl/BUILD.gn
 @@ -153,6 +153,7 @@ if (is_msan) {
@@ -2204,7 +2265,7 @@ index 708bb206626..883414554c8 100644
    friend = [ ":*" ]
    deps = [ "//third_party/boringssl/src/third_party/fiat:fiat_license" ]
 diff --git a/ui/linux/display_server_utils.cc b/ui/linux/display_server_utils.cc
-index 5d8ad66686e..a3090f5e2e7 100644
+index 5d8ad66686e65..a3090f5e2e74e 100644
 --- a/ui/linux/display_server_utils.cc
 +++ b/ui/linux/display_server_utils.cc
 @@ -53,7 +53,7 @@ void SetOzonePlatformForLinuxIfNeeded(base::CommandLine& command_line) {
@@ -2225,30 +2286,8 @@ index 5d8ad66686e..a3090f5e2e7 100644
  #if BUILDFLAG(SUPPORTS_OZONE_X11)
    command_line.AppendSwitchASCII(switches::kOzonePlatform, "x11");
  #endif
-diff --git a/ui/qt/qt_ui.cc b/ui/qt/qt_ui.cc
-index 25eb5aeadb1..d8dc0287b89 100644
---- a/ui/qt/qt_ui.cc
-+++ b/ui/qt/qt_ui.cc
-@@ -215,6 +215,17 @@ bool QtUi::Initialize() {
-   if (!libqt_shim) {
-     return false;
-   }
-+
-+#ifndef NO_GOSTSSL
-+  if (qt_version_ == 6) {
-+    auto env = base::Environment::Create();
-+    if (!env->HasVar("QT_QPA_PLATFORMTHEME")) {
-+      // Avoid KDEPlasmaPlatformTheme6.so in the browser process.
-+      env->SetVar("QT_QPA_PLATFORMTHEME", "generic");
-+    }
-+  }
-+#endif // GOSTSSL
-+
-   void* create_qt_interface = dlsym(libqt_shim, "CreateQtInterface");
-   DCHECK(create_qt_interface);
-   shim_.reset((reinterpret_cast<decltype(&CreateQtInterface)>(
 diff --git a/ui/webui/resources/cr_components/searchbox/searchbox.ts b/ui/webui/resources/cr_components/searchbox/searchbox.ts
-index efe475a4a5e..e39f084cc65 100644
+index efe475a4a5e7c..e39f084cc65be 100644
 --- a/ui/webui/resources/cr_components/searchbox/searchbox.ts
 +++ b/ui/webui/resources/cr_components/searchbox/searchbox.ts
 @@ -151,10 +151,10 @@ export class SearchboxElement extends SearchboxElementBase implements
@@ -2267,4 +2306,5 @@ index efe475a4a5e..e39f084cc65 100644
  
    protected callbackRouter_: PageCallbackRouter;
 -- 
+2.51.0
 


### PR DESCRIPTION
Fixes: https://github.com/deemru/Chromium-Gost/issues/135

Вроде бы нормальное исправление, без регрессии по внешнему виду. Проверял native messaging, но именно Криптопрошний не проверял.

Во вложении патч с описанием. Планирую попробовать передать его в апстрим.

[0001-Fix-fork-deadlock-in-GetAppOutputInternal-via-raw-cl.patch](https://github.com/user-attachments/files/29650075/0001-Fix-fork-deadlock-in-GetAppOutputInternal-via-raw-cl.patch)
