### PR TITLE
Исправление редкой ошибки синхронизации в prepare-скриптах; рефакторинг

### DIFF
--- a/build_android/chromium-gost-env.sh
+++ b/build_android/chromium-gost-env.sh
@@ -2,6 +2,7 @@ export CHROMIUM_TAG=$(cat ../VERSION)
 export CHROMIUM_FLAGS="$(cat ../FLAGS)"
 export CHROMIUM_PATH=/build/chromium/src
 export BORINGSSL_PATH=$CHROMIUM_PATH/third_party/boringssl/src
+export SEARCH_ENGINES_PATH=$CHROMIUM_PATH/third_party/search_engines_data/resources
 export DEPOT_TOOLS_PATH=/build/depot_tools/
 export CHROMIUM_GOST_REPO=$(pwd)/..
 export CHROMIUM_PRIVATE_ARGS= 

--- a/build_android/chromium-gost-prepare.sh
+++ b/build_android/chromium-gost-prepare.sh
@@ -8,9 +8,16 @@ export GOST_BRANCH=GOSTSSL-$CHROMIUM_TAG
 
 cd $CHROMIUM_PATH/.git || exit
 cd $BORINGSSL_PATH/.git || exit
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources && git reset HEAD --hard && git clean -fd
+cd $SEARCH_ENGINES_PATH/.git || exit
 
 cd $BORINGSSL_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
+git reset HEAD --hard && git clean -fd
+
+cd $SEARCH_ENGINES_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
 git reset HEAD --hard && git clean -fd
 
 cd $CHROMIUM_PATH
@@ -69,7 +76,7 @@ git checkout -f -b $GOST_BRANCH
 git branch -D temp
 git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/boringssl.patch || exit
 
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources
+cd $SEARCH_ENGINES_PATH
 git checkout -f -b temp
 git show-ref --quiet refs/heads/$GOST_BRANCH && git branch -D $GOST_BRANCH
 git checkout -f -b $GOST_BRANCH

--- a/build_linux/chromium-gost-env.sh
+++ b/build_linux/chromium-gost-env.sh
@@ -2,6 +2,7 @@ export CHROMIUM_TAG=$(cat ../VERSION)
 export CHROMIUM_FLAGS="$(cat ../FLAGS)"
 export CHROMIUM_PATH=/c/chromium/src
 export BORINGSSL_PATH=$CHROMIUM_PATH/third_party/boringssl/src
+export SEARCH_ENGINES_PATH=$CHROMIUM_PATH/third_party/search_engines_data/resources
 export DEPOT_TOOLS_PATH=/c/depot_tools
 export CHROMIUM_GOST_REPO=$(pwd)/..
 export CHROMIUM_PRIVATE_ARGS= 

--- a/build_linux/chromium-gost-prepare.sh
+++ b/build_linux/chromium-gost-prepare.sh
@@ -8,9 +8,16 @@ export GOST_BRANCH=GOSTSSL-$CHROMIUM_TAG
 
 cd $CHROMIUM_PATH/.git || exit
 cd $BORINGSSL_PATH/.git || exit
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources && git reset HEAD --hard && git clean -fd
+cd $SEARCH_ENGINES_PATH/.git || exit
 
 cd $BORINGSSL_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
+git reset HEAD --hard && git clean -fd
+
+cd $SEARCH_ENGINES_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
 git reset HEAD --hard && git clean -fd
 
 cd $CHROMIUM_PATH
@@ -62,7 +69,7 @@ git checkout -f -b $GOST_BRANCH
 git branch -D temp
 git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/boringssl.patch || exit
 
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources
+cd $SEARCH_ENGINES_PATH
 git checkout -f -b temp
 git show-ref --quiet refs/heads/$GOST_BRANCH && git branch -D $GOST_BRANCH
 git checkout -f -b $GOST_BRANCH

--- a/build_mac/chromium-gost-env.sh
+++ b/build_mac/chromium-gost-env.sh
@@ -2,6 +2,7 @@ export CHROMIUM_TAG=$(cat ../VERSION)
 export CHROMIUM_FLAGS=$(cat ../FLAGS)
 export CHROMIUM_PATH=/Users/macav/Desktop/c/chromium/src
 export BORINGSSL_PATH=$CHROMIUM_PATH/third_party/boringssl/src
+export SEARCH_ENGINES_PATH=$CHROMIUM_PATH/third_party/search_engines_data/resources
 export DEPOT_TOOLS_PATH=/Users/macav/Desktop/c/depot_tools
 export CHROMIUM_GOST_REPO=$(pwd)/..
 export CHROMIUM_PRIVATE_ARGS= 

--- a/build_mac/chromium-gost-prepare.sh
+++ b/build_mac/chromium-gost-prepare.sh
@@ -8,9 +8,16 @@ export GOST_BRANCH=GOSTSSL-$CHROMIUM_TAG
 
 cd $CHROMIUM_PATH/.git || exit
 cd $BORINGSSL_PATH/.git || exit
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources && git reset HEAD --hard && git clean -fd
+cd $SEARCH_ENGINES_PATH/.git || exit
 
 cd $BORINGSSL_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
+git reset HEAD --hard && git clean -fd
+
+cd $SEARCH_ENGINES_PATH
+git rebase --abort 2>/dev/null
+git checkout --detach HEAD
 git reset HEAD --hard && git clean -fd
 
 cd $CHROMIUM_PATH
@@ -63,7 +70,7 @@ git checkout -f -b $GOST_BRANCH
 git branch -D temp
 git am --3way --ignore-space-change < $CHROMIUM_GOST_REPO/patch/boringssl.patch || exit
 
-cd $CHROMIUM_PATH/third_party/search_engines_data/resources
+cd $SEARCH_ENGINES_PATH
 git checkout -f -b temp
 git show-ref --quiet refs/heads/$GOST_BRANCH && git branch -D $GOST_BRANCH
 git checkout -f -b $GOST_BRANCH

--- a/build_windows/chromium-gost-env.bat
+++ b/build_windows/chromium-gost-env.bat
@@ -2,6 +2,7 @@ set /p CHROMIUM_TAG=<..\VERSION
 set /p CHROMIUM_FLAGS=<..\FLAGS
 set CHROMIUM_PATH=U:\chromium\src
 set BORINGSSL_PATH=%CHROMIUM_PATH%\third_party\boringssl\src
+set SEARCH_ENGINES_PATH=%CHROMIUM_PATH%\third_party\search_engines_data\resources
 set DEPOT_TOOLS_PATH=U:\depot_tools
 set CHROMIUM_GOST_REPO=%~dp0..\
 set SEVENZIP_PATH="C:\Program Files\7-Zip\"

--- a/build_windows/chromium-gost-prepare.bat
+++ b/build_windows/chromium-gost-prepare.bat
@@ -10,12 +10,12 @@ cd %BORINGSSL_PATH%\.git || goto :finish
 cd %SEARCH_ENGINES_PATH%\.git || goto :finish
 
 cd %BORINGSSL_PATH%
-call git rebase --abort 2>/dev/null
+call git rebase --abort 2>nul 
 call git checkout --detach HEAD
 call git reset HEAD --hard && call git clean -fd
 
 cd %SEARCH_ENGINES_PATH%
-call git rebase --abort 2>/dev/null
+call git rebase --abort 2>nul
 call git checkout --detach HEAD
 call git reset HEAD --hard && call git clean -fd
 

--- a/build_windows/chromium-gost-prepare.bat
+++ b/build_windows/chromium-gost-prepare.bat
@@ -7,9 +7,16 @@ set GOST_BRANCH=GOSTSSL-%CHROMIUM_TAG%
 
 cd %CHROMIUM_PATH%\.git || goto :finish
 cd %BORINGSSL_PATH%\.git || goto :finish
-cd %CHROMIUM_PATH%\third_party\search_engines_data\resources && call git reset HEAD --hard && call git clean -fd
+cd %SEARCH_ENGINES_PATH%\.git || goto :finish
 
 cd %BORINGSSL_PATH%
+call git rebase --abort 2>/dev/null
+call git checkout --detach HEAD
+call git reset HEAD --hard && call git clean -fd
+
+cd %SEARCH_ENGINES_PATH%
+call git rebase --abort 2>/dev/null
+call git checkout --detach HEAD
 call git reset HEAD --hard && call git clean -fd
 
 cd %CHROMIUM_PATH%
@@ -61,7 +68,7 @@ call git checkout -f -b %GOST_BRANCH%
 call git branch -D temp
 call git am --3way --ignore-space-change < %CHROMIUM_GOST_REPO%\patch\boringssl.patch || goto :finish
 
-cd %CHROMIUM_PATH%\third_party\search_engines_data\resources
+cd %SEARCH_ENGINES_PATH%
 call git checkout -f -b temp
 call git show-ref --quiet refs/heads/%GOST_BRANCH% && call git branch -D %GOST_BRANCH%
 call git checkout -f -b %GOST_BRANCH%


### PR DESCRIPTION
Привет!

Иногда сталкиваюсь с такими ошибками:
```
Syncing projects:  98% (240/243) src/third_party/boringssl/src
src/third_party/search_engines_data/resources (ERROR)
----------------------------------------
[0:00:01] Started.
[0:00:01] Finished running: git rev-list -n 1 HEAD
[0:00:01] Finished running: git rev-parse --abbrev-ref=strict HEAD
[0:00:01] Finished running: git -c core.quotePath=false status --porcelain
[0:00:02] Finished running: git -c core.quotePath=false diff --name-only refs/remotes/origin/main
[0:00:02] _____ src/third_party/search_engines_data/resources : Attempting rebase onto cf814b5cc732a437b4ee636f1c7907f8f1ced51a...
----------------------------------------
Error: 168> Conflict while rebasing this branch.
168> Fix the conflict and run gclient again.
168> See 'man git-rebase' for details.
```
Хочется упростить жизнь:
 - унифицировал путь до `search_engines_data/resources` в SEARCH_ENGINES_PATH
 - добавил git команд, чтобы поправить проблему